### PR TITLE
Adds Alttext.ai Options and Umbraco Logging

### DIFF
--- a/Blend.Umbraco.AltTextAi.Umbraco14/Blend.Umbraco.AltTextAi.Umbraco14.csproj
+++ b/Blend.Umbraco.AltTextAi.Umbraco14/Blend.Umbraco.AltTextAi.Umbraco14.csproj
@@ -7,7 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms" Version="14.0.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
+    <PackageReference Include="Umbraco.Cms" Version="14.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Blend.Umbraco.AltTextAi.sln
+++ b/Blend.Umbraco.AltTextAi.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blend.Umbraco.AltTextAi", "Blend.Umbraco.AltTextAi\Blend.Umbraco.AltTextAi.csproj", "{DA31B54A-14D7-459B-8509-C3F784599FCD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blend.Umbraco.AltTextAi.Umbraco13", "Blend.Umbraco.AltTextAi.Umbraco13\Blend.Umbraco.AltTextAi.Umbraco13.csproj", "{237A391E-A2B9-4C98-8EF3-41E5574EBB47}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blend.Umbraco.AltTextAi.Umbraco14", "Blend.Umbraco.AltTextAi.Umbraco14\Blend.Umbraco.AltTextAi.Umbraco14.csproj", "{2A8FA0DE-4168-4E94-8F04-7A5978C0B203}"
 EndProject
 Global
@@ -14,21 +12,17 @@ Global
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{DA31B54A-14D7-459B-8509-C3F784599FCD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DA31B54A-14D7-459B-8509-C3F784599FCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DA31B54A-14D7-459B-8509-C3F784599FCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DA31B54A-14D7-459B-8509-C3F784599FCD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{237A391E-A2B9-4C98-8EF3-41E5574EBB47}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{237A391E-A2B9-4C98-8EF3-41E5574EBB47}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{237A391E-A2B9-4C98-8EF3-41E5574EBB47}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{237A391E-A2B9-4C98-8EF3-41E5574EBB47}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2A8FA0DE-4168-4E94-8F04-7A5978C0B203}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2A8FA0DE-4168-4E94-8F04-7A5978C0B203}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2A8FA0DE-4168-4E94-8F04-7A5978C0B203}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2A8FA0DE-4168-4E94-8F04-7A5978C0B203}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/Blend.Umbraco.AltTextAi/Blend.Umbraco.AltTextAi.csproj
+++ b/Blend.Umbraco.AltTextAi/Blend.Umbraco.AltTextAi.csproj
@@ -14,7 +14,7 @@
     <AssemblyOriginatorKeyFile>..\..\..\Downloads\codesign\cert.pem</AssemblyOriginatorKeyFile>
     <AssemblyVersion>1.0.2</AssemblyVersion>
     <FileVersion>1.0.2</FileVersion>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -29,12 +29,12 @@
 
 
   <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
     <PackageReference Include="Umbraco.Cms.Core" Version="13.*-14.*" />
     <PackageReference Include="Umbraco.Cms.Web.Common" Version="13.*-14.*" />
   </ItemGroup>

--- a/Blend.Umbraco.AltTextAi/Composing/Composer.cs
+++ b/Blend.Umbraco.AltTextAi/Composing/Composer.cs
@@ -14,6 +14,7 @@ public class Composer : IComposer
         {
             builder.Config.GetSection(nameof(Configuration.AltTextAi)).Bind(options);
         });
+
         builder.AddNotificationHandler<MediaSavedNotification, MediaSavedAltTextHandler>();
     }
 }

--- a/Blend.Umbraco.AltTextAi/Configuration/AltTextAi.cs
+++ b/Blend.Umbraco.AltTextAi/Configuration/AltTextAi.cs
@@ -5,9 +5,20 @@ namespace Blend.Umbraco.AltTextAi.Configuration;
 [DataContract]
 public class AltTextAi
 {
-    [DataMember(Name="AltTextAiApiKey")]
-    public string AltTextAiApiKey { get; set; }
-    
-    [DataMember(Name="ImageAltTextProperty")]
-    public string ImageAltTextProperty { get; set; }
+    [DataMember(Name = "AltTextAiApiKey")]
+    public string AltTextAiApiKey { get; set; } = string.Empty;
+
+    [DataMember(Name = "ImageAltTextProperty")]
+    public string ImageAltTextProperty { get; set; } = string.Empty;
+
+    // the length of the alt text to skip the AI generation
+    // shorter than this setting will (re)generate the alt text
+    // set to 0 to skip generation if alt text is not empty
+    [DataMember(Name = "AltTextLengthToSkip")]
+    public int AltTextLengthToSkip { get; set; } = 0;
+
+    // an array of up to 6 keywords to use in the AI generation
+    // useful for adding SEO context to the generated alt text
+    [DataMember(Name = "AltTextKeyWords")]
+    public string[] AltTextKeyWords { get; set; } = Array.Empty<string>();
 }

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Next, you'll need to add a section to your appsettings.json file to configure th
 ```json
   "AltTextAi": {
     "ImageAltTextProperty": "altText",
-    "AltTextAiApiKey": "<YOUR API KEY GOES HERE>"
+    "AltTextAiApiKey": "<YOUR API KEY GOES HERE>",
+    "AltTextLengthToSkip": 0,
+    "AltTextKeyWords": []
   }
 ```
 
@@ -46,6 +48,13 @@ This is where the package will look for and write generated alt text.
 
 In the "AltTextAiApiKey" setting, add an API Key from your AltTextAI account. You'll need 
 an alttext.ai account for this. A free trial is available. 
+
+The "AltTextLengthToSkip" setting allows you to skip generating alt text for media items where
+the alt text is longer than the specified length. Set to 0 to skip generating alt text when the field is not empty.
+This can be useful if you have manually added alt text to some media items and don't want to overwrite it.
+
+The "AltTextKeyWords" setting allows you to specify keywords that will be used to give SEO context to
+AltText.ai when generating the alt text. You can specify up to 6 keywords in the string array.
 
 Once you have an account, the [AltText.AI documentation explains how to create an API Key](https://alttext.ai/docs/webui/account/#api-keys).
 


### PR DESCRIPTION
Hi @joekepley ~ This is an awesome package we started using on our sites (v13/v14) recently, thanks for sharing! I made a few updates to your initial work and have included in this PR for your consideration.

I added two additional config options - `AltTextLengthToSkip` and `AltTextKeyWords` - that can be used to set a threshold for exisiting alt text length to be updated or skipped and the keywords option to send to AltText.ai to add some context when using the alt text for SEO purposes (we've found this works really welll for that).

I also added some logging in (okay, quite a lot of logging) and a tiny refactor of the main method - feel free to use all that or not.

Let me know if you have any questions of feedback and thanks again for this package!